### PR TITLE
Fixed ns definition in status-monitor application-server document

### DIFF
--- a/projects/status-monitor-deps/application-server.md
+++ b/projects/status-monitor-deps/application-server.md
@@ -15,8 +15,8 @@ Add the compojure library for routing of requests
 ```clojure
  :deps
  {org.clojure/clojure {:mvn/version "1.10.1"}
-  http-kit            {:mvn/version "2.3.0"}
-  compojure           {:mvn/version "1.6.1"}}
+  http-kit            {:mvn/version "2.5.0"}
+  compojure           {:mvn/version "1.6.2"}}
 ```
 
 
@@ -28,7 +28,7 @@ Include the http-kit server namespace and the compojure core namespace as requir
 ```clojure
 (ns practicalli.status-monitor-service
   (:gen-class)
-  (:require [http-kit-server :as app-server]
+  (:require [org.httpkit.server :as app-server]
             [compojure.core :refer [defroutes GET]]))
 ```
 


### PR DESCRIPTION
Fixed an issue with the ns definition and also updated the library versions for compojure/http-kit to the latest ones.