### PR TITLE
Fix spelling in H2 docs

### DIFF
--- a/relational-databases-and-sql/h2-database/index.md
+++ b/relational-databases-and-sql/h2-database/index.md
@@ -56,7 +56,7 @@ Edit the `project.clj` configuration file and add the H2 library to the :dev-dep
 
 
 ## Auto-increment values in H2 database
-The `IDENTITY` type is used for automatically generating an incriminating 64-bit long integer in H2 database.
+The `IDENTITY` type is used for automatically generating an incrementing 64-bit long integer in H2 database.
 
 ```sql
 CREATE TABLE public.account (

--- a/relational-databases-and-sql/h2-database/schema-design.md
+++ b/relational-databases-and-sql/h2-database/schema-design.md
@@ -3,7 +3,7 @@ Key concepts and syntax for designing database schema for the H2 database
 
 
 ## Auto-increment values in H2 database
-The `IDENTITY` type is used for automatically generating an incriminating 64-bit long integer in H2 database.
+The `IDENTITY` type is used for automatically generating an incrementing 64-bit long integer in H2 database.
 
 ```sql
 CREATE TABLE public.account (


### PR DESCRIPTION
The meaning of the text is significantly affected by the use of 'incriminating' instead of 'incrementing' in the H2 docs.